### PR TITLE
Popup details on markers, small fix for map dragged

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -206,6 +206,9 @@ function getTag() {
 	case 'Charging':
 	  tag="amenity=charging_station";
 	  break;
+        case 'Bus station':
+	  tag="highway=bus_stop";
+	  break;
 	default:
 	  tag='';
 	  break;

--- a/index.html
+++ b/index.html
@@ -61,11 +61,12 @@
 	<option value="Tabletennis">Tabletennis</option>
 	<option value="Pharmacy">Pharmacy</option>
 	<option value="ATM">ATM</option>
-	<option value="Taxi">cabstand</option>
+	<option value="Taxi">Cabstand</option>
 	<option value="Fuel">Gas station</option>
 	<option value="Telephone">Telephone</option>
 	<option value="Water">Drinking water</option>
 	<option value="Charging">EV charging</option>
+  <option value="Bus station">Bus station</option>
 	</select>
 
 <p>IS</p>

--- a/index_mobile.html
+++ b/index_mobile.html
@@ -60,11 +60,12 @@
 	<option value="Tabletennis">Tabletennis</option>
 	<option value="Pharmacy">Pharmacy</option>
 	<option value="ATM">ATM</option>
-	<option value="Taxi">cabstand</option>
+	<option value="Taxi">Cabstand</option>
 	<option value="Fuel">Gas station</option>
 	<option value="Telephone">Telephone</option>
 	<option value="Water">Drinking water</option>
 	<option value="Charging">EV charging</option>
+        <option value="Bus station">Bus station</option>
 	</select>
 
 <p>IS</p>


### PR DESCRIPTION
Popup details on markers (OSM-Tags if not emty): name, operator, collection_times, opening_hours, phone, website

post_box example:
![postbox-collection_time](https://f.cloud.github.com/assets/465714/1623791/7716f8da-56b8-11e3-93f3-b11aa098d3fa.png)
