### PR TITLE
Fix text not fitting one line in header on mobiles

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,8 +13,6 @@ var myLocationCircle = null;
 var isMobile = false;
 var poiData = null;
 
-
-
 function initMap(loc, zoom) {
 	
 
@@ -447,4 +445,29 @@ function fillMobileSelectionBox(data) {
                 //    $('#mySelect').append( new Option(text,val,defaultSelected,nowSelected) );
 
             })
+
+  // Now that the selection box is filled, adjust font-size of the whole
+  // inputarea content so that it fits one line
+  $('#inputarea').textFontAdjust($('#inputarea-content'));
+}
+
+// A small jQuery plugin for scaling down the font-size of an element until the
+// parent container isn't higher than allowed
+$.fn.textFontAdjust = function(subElem, options) {
+  var config = $.extend({
+    maxFontPerc : 100,
+    minFontPerc : 25,
+    additionalWidthToDecrease: 0
+  },options);
+  var fontSizePerc = config.maxFontPerc,
+      textElem = $(subElem),
+      maxHeight = '40',
+      maxWidth = $(this).width()-config.additionalWidthToDecrease;
+  var textHeight, textWidth;
+  do {
+    textElem.css('font-size', fontSizePerc + '%');
+    fontSizePerc = fontSizePerc - 1;
+  } while ((textElem.height() > maxHeight || textElem.width() > maxWidth) && fontSizePerc > config.minFontPerc) {
+    return this;
+  }
 }

--- a/app/app_mobile.css
+++ b/app/app_mobile.css
@@ -8,18 +8,18 @@ html,body{
 }
 
 #map{
-    height: -webkit-calc(100% - 100px);
-    height: -moz-calc(100% - 100px);
-    height: calc(100% - 100px);
-    top:100px;
+    height: -webkit-calc(100% - 60px);
+    height: -moz-calc(100% - 60px);
+    height: calc(100% - 60px);
+    top:60px;
 }
 
 #inputarea{
 	position:absolute;
-	height:100px;
-    width:100%;
+	height:60px;
+  width:100%;
 	top:0px;
-	padding:5px;
+	padding:15px 10px;
 	z-index:10;
 	background-color:#000;
 	font-size:25px;

--- a/index_mobile.html
+++ b/index_mobile.html
@@ -37,6 +37,7 @@
 </head>
 <body>
 <div id="inputarea">
+  <span id="inputarea-content">
 	THE NEXT
 
 
@@ -56,7 +57,7 @@
     <option value="Bus station">Bus station</option> -->
 	</select>
 
-IS<br>
+  IS</span>
 </div>
 
 <div id="loading"><i class="fa fa-spinner fa-spin fa-large"></i> searching for you...</div>


### PR DESCRIPTION
Hi,

I was annoyed by the header spanning 2 lines just for the word IS in the second line, so I added code to automatically adjust the font-size of the whole input area so that it fits in a fixed height, no matter how wide the screen is.

Works great for me. Hope you like it!

Cheers
Basti
