### PR TITLE
add some elements to mobile, prioritize order

### DIFF
--- a/content.json
+++ b/content.json
@@ -1,31 +1,56 @@
 {
-    "playground" : {
-                    "osm" : "leisure=playground",
-                    "lang-de":"Spielplatz",
-                    "lang-en":"Playground"
-                    },
-    "postbox" : {
-                    "osm" : "amenity=post_box",
-                    "lang-de":"Briefkasten",
-                    "lang-en":"Postbox"
-                    },
-
     "atm" : {
                     "osm" : "amenity=atm;atm=yes",
                     "lang-de":"Geldautomat",
                     "lang-en":"ATM"
                     },
 
-    "telephone" : {
-                    "osm" : "amenity=telephone",
-                    "lang-de":"Telefon",
-                    "lang-en":"Telephone"
+    "wifi" : {
+                    "osm" : "internet_access=wlan",
+                    "lang-de":"Wifi",
+                    "lang-en":"Wifi"
+                    },
+
+    "water" : {
+                    "osm" : "amenity=drinking_water",
+                    "lang-de":"Trinkwasser",
+                    "lang-en":"Drinking Water"
                     },
 
     "cafe" : {
                     "osm" : "amenity=cafe",
                     "lang-de":"Café",
                     "lang-en":"Café"
+                    },
+
+    "toilet" : {
+                    "osm" : "amenity=toilets",
+                    "lang-de":"Öffentliche Toilette",
+                    "lang-en":"Public Toilet"
+                    },
+
+    "busstop" : {
+                    "osm" : "highway=bus_stop ",
+                    "lang-de":"Bushaltestelle",
+                    "lang-en":"Bus Stop"
+                    },
+
+    "playground" : {
+                    "osm" : "leisure=playground",
+                    "lang-de":"Spielplatz",
+                    "lang-en":"Playground"
+                    },
+
+    "postbox" : {
+                    "osm" : "amenity=post_box",
+                    "lang-de":"Briefkasten",
+                    "lang-en":"Postbox"
+                    },
+
+    "telephone" : {
+                    "osm" : "amenity=telephone",
+                    "lang-de":"Telefon",
+                    "lang-en":"Telephone"
                     },
 
     "pharmacy" : {
@@ -46,28 +71,10 @@
                     "lang-en":"Gas Station"
                     },
 
-    "water" : {
-                    "osm" : "amenity=drinking_water",
-                    "lang-de":"Trinkwasser",
-                    "lang-en":"Drinking Water"
-                    },
-
     "charging" : {
                     "osm" : "amenity=charging_station",
                     "lang-de":"Ladesäule",
                     "lang-en":"Charging Station"
-                    },
-
-    "busstop" : {
-                    "osm" : "highway=bus_stop ",
-                    "lang-de":"Bushaltestelle",
-                    "lang-en":"Bus Stop"
-                    },
-
-    "wifi" : {
-                    "osm" : "internet_access=wlan",
-                    "lang-de":"Wifi",
-                    "lang-en":"Wifi"
                     },
 
     "tablesoccer" : {


### PR DESCRIPTION
- add table tennis to mobile as well
- add public toilet to mobile, prioritize order of elements a bit

@homtec can we combine the mobile and desktop list into one by the way?

In general it seems that we should do the mobile/desktop distinction via media queries only. Actually the mobile site works on desktop quite well, especially because the »the next […] is« is in one line. The social media and other notes could just go on the right, and vanish on mobile behind a dropdown.
