### PR TITLE
CSS changes for restyled fitting header bar (header-styling-calc branch)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -19,13 +19,20 @@ html,body{
 	height:60px;
   width:100%;
 	top:0px;
-	padding:15px 10px;
+	padding:8px 10px;
 	z-index:10;
 	background-color:#000;
 	font-size:25px;
 	font-family: 'Open Sans', sans-serif;
 	font-weight: 400;
 	color: #fff;
+}
+
+#mydropdown {
+  width: calc(100% - 155px);
+  margin: 0 5px;
+  padding-left: 2px;
+  height: 45px;
 }
 
 .buttons {


### PR DESCRIPTION
Hi, this is a small CSS change so that the header dropdown and text scales with screen size. I've also attached some test images using Browser Stack.

![header-styling-calc iphone](https://cloud.githubusercontent.com/assets/10274245/12243264/6e87f638-b895-11e5-8c9d-9e7f8dcab70f.jpeg)
![header-styling-calc chrome](https://cloud.githubusercontent.com/assets/10274245/12243263/6e876ede-b895-11e5-9e85-81dee5629a0c.png)
![header-styling-calc android](https://cloud.githubusercontent.com/assets/10274245/12243265/6e96087c-b895-11e5-975d-2202222379d6.jpeg)

Cheers,

James
