### PR TITLE
Add offline/online detection

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -28,6 +28,20 @@ html,body{
 	color: #fff;
 }
 
+#online-offline-pane {
+  position: absolute;
+  top: 25px;
+  height: 35px;
+  line-height: 35px;
+  width: 100%;
+	background-color: white;
+  text-align: center;
+  font-size: 17px;
+  color: white;
+  transition: all 0.5s ease-in-out;
+  z-index: 1;
+}
+
 .buttons {
     color: white;
     font-size: 35px;

--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
 
   IS</span>
 </div>
-
+<div id="online-offline-pane">
+</div>
 <div id="loading"><i class="fa fa-spinner fa-spin fa-large"></i> searching for you...</div>
 <div id="info_overlay">
 	<h1>About this project</h1>

--- a/index_mobile.html
+++ b/index_mobile.html
@@ -42,7 +42,8 @@
 
   IS</span>
 </div>
-
+<div id="online-offline-pane">
+</div>
 <div id="loading"><i class="fa fa-spinner fa-spin fa-large"></i> searching for you...</div>
 <div id="info_overlay">
 	<h1>About this project</h1>


### PR DESCRIPTION
Added HTML banner, offline-online-pane, added helper functions goOffline, goOnline, and animateOnlineOfflinePane, and bound goOffline and goOnline to the following:

* tileload/tileerror Leaflet events (tilerror is undocumented, but it looks like it's supported and will be added to documentation soon: https://github.com/Leaflet/Leaflet/issues/2756, https://github.com/Leaflet/Leaflet/issues/2885)

* navigator.onLine online/offline events

* success or failure of getJSON AJAX request in loadPOIs function

Offline banner is always displayed when error is detected, online is only displayed when status is changed from offline to online (which is the purpose of the wasOnline global variable).

Not sure what you were intending for the design of the banner, I've made it so it slides down as a solid red/green banner from the top, 100% width and 35px height, stays for 2.5 seconds, then slides back to leave 3px of green or red exposed under the header, to give an ongoing display of connection status. Some pictures from iPhone, Android, desktop Chrome below. Also tested on IE11 and desktop Firefox, haven't seen any problems:

![online-offline-detection iphone android](https://cloud.githubusercontent.com/assets/10274245/12362569/ed8b4060-bbbb-11e5-9861-3a3888dd8cd8.png)
![online-offline-detection chrome](https://cloud.githubusercontent.com/assets/10274245/12362570/ed8c20ac-bbbb-11e5-8f48-2f57d4cd2a28.png)

Cheers!